### PR TITLE
update README.md, newman option handling changed in v3.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Since **Newman** requires Node.js, use the [Pipelines](https://github.com/stelli
 Create a [buildspec-test.yml](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#build-spec-ref-syntax) to test the service.  The buildspec should have the following configurations:
 
 * Run the command `npm install newman --global` in the **install** phase
-* Run the command `newman run -e env.json -r html,cli src/test/postman/collection.json` in the **build** phase
+* Run the command `newman run src/test/postman/collection.json -e env.json -r html,cli` in the **build** phase
 * Use the path `newman/*` for **files** in the **artifacts** section
 
 #  Pipeline


### PR DESCRIPTION
The options for newman run now need to come after the collection. This seems to have changed between v3.8.3 and v3.9.0, when newman switched to using commander.